### PR TITLE
LPS-76859 Added 'position' and 'z-index' to .visible-interaction to b…

### DIFF
--- a/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_controls.scss
+++ b/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_controls.scss
@@ -82,6 +82,8 @@ body.portlet {
 	&:active, &:hover, &:focus, &.active {
 		.visible-interaction {
 			display: inherit;
+			position: relative;
+			z-index: 400;
 		}
 	}
 }


### PR DESCRIPTION
…e viewable and clickable

The ellipses used to edit content are being covered and not clickable by another content.

Adding position: relative and z-index: 400 will allow these ellipses to be viewable and clickable to the user.